### PR TITLE
Fix some formatting issues and change indexing

### DIFF
--- a/GBTL.tex
+++ b/GBTL.tex
@@ -1,5 +1,6 @@
 \subsection{GBTL: GraphBLAS Template Library}
- 
+\label{sec:gbtl}
+
 The first version of the GraphBLAS Template Library (GBTL) was written in C++ 
 when the GraphBLAS C API project was just beginning.  It was used, in part, 
 to study early ideas under discussion in the specification process and was released as a proof of concept 

--- a/GraphBLAS.tex
+++ b/GraphBLAS.tex
@@ -6,8 +6,8 @@
 %% GABB paper where we introduced the C API
 Consider a graph represented as an $n$-by-$n$ adjacency matrix $\matrix{A}$,
 where $A_{ij}$ is the weight of the edge from vertex $i$ to vertex $j$,
-and a second $k$-by-$n$ matrix $\matrix{B}$ representing a subset (of size k) of the vertices
-in the graph, such that $B_{ji}$ is $1$ if the $j$th element of the subset is vertex $i$
+and a second $k$-by-$n$ matrix $\matrix{B}$ representing a subset (of size $k$) of the vertices
+in the graph, such that $B_{hi}$ is $1$ if the $h$th element of the subset is vertex $i$
 (and all other elements of $\matrix{B}$ are 0).  The traditional matrix
 product $\matrix{B} \times \matrix{A}$ over real arithmetic of these two matrices returns 
 the cost based on the edge weights of reaching the set of vertices

--- a/IBM.tex
+++ b/IBM.tex
@@ -39,7 +39,7 @@ programs can bind to them as specified. Objects internal to the library
 are declared as C++ classes, with member methods doing the actual work.
 We want to emphasize that this is a C++ implementation of a C API, and
 not an API for GraphBLAS that exploits C++ features, as other efforts
-are pursuing~\cite{gbtl-github}.
+are pursuing~\cite{gbtl-github} (see \autoref{sec:gbtl}).
 
 The contents of a GraphBLAS vector object are implemented using standard
 C++ containers.  An unordered set of indices (\code{uset<GrB\_Index>})

--- a/suitesparse.tex
+++ b/suitesparse.tex
@@ -47,7 +47,7 @@ masked variants.  With this code generation mechanism, 6 functions
 containing 2 versions of Gustavson's method (no mask / with mask),
 three versions of the dot product (no mask / with mask / with complemented
 mask) and one version of the heap method, automatically expand into the 960
-unique semirings supported by the built-in operators in GraphBLAS
+unique semirings supported by the built-in operators in GraphBLAS.
 SuiteSparse:GraphBLAS adds a few extensions to the set of operators;
 Using the  built-in types and operators from the GraphBLAS C API,
 600 unique semirings can be constructed.  All of them are as fast, or much


### PR DESCRIPTION
I made some changes to the paper. The only major change is in Section II, where I reindexed matrix B as I felt that using "B_ji" in the same sentence with "A_ij" and "vertex j" makes the notation difficult to follow for newcomers. Still, none of the proposed changes is terribly important, so feel free to discard this PR.

What's more important is that I was trying to find a PDF version of this paper but search engines only return this repository. Will this paper be released as part of the GrAPL workshop proceedings?

In the meantime, I uploaded a version (compiled from `GrAPL19:master`) to my homepage at http://home.mit.bme.hu/~szarnyas/papers/lagraph-grapl19.pdf for personal use. (It's accompanied by a [`robots.txt`](http://home.mit.bme.hu/~szarnyas/papers/robots.txt) file so it will not be indexed by Scholar/Academic/etc.)

*Update:* I just realized the GrAPL'19 workshop is happening _tomorrow_ - the [website](http://hpc.pnl.gov/grapl/) says "March 20, 2019", but it's actually May 20.